### PR TITLE
Uri building, preventing usage of escaped slashes

### DIFF
--- a/cdp4common/pom.xml
+++ b/cdp4common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/cdp4common/pom.xml
+++ b/cdp4common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/cdp4common/pom.xml
+++ b/cdp4common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/cdp4dal/pom.xml
+++ b/cdp4dal/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rheagroup</groupId>
         <artifactId>cdp4-sdk4j-parent</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -43,7 +43,7 @@
     </scm>
 
     <properties>
-        <cdp4common.version>3.1.1</cdp4common.version>
+        <cdp4common.version>3.1.0</cdp4common.version>
     </properties>
 
     <dependencies>

--- a/cdp4dal/pom.xml
+++ b/cdp4dal/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rheagroup</groupId>
         <artifactId>cdp4-sdk4j-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -43,7 +43,7 @@
     </scm>
 
     <properties>
-        <cdp4common.version>3.1.0</cdp4common.version>
+        <cdp4common.version>3.1.1</cdp4common.version>
     </properties>
 
     <dependencies>

--- a/cdp4dal/pom.xml
+++ b/cdp4dal/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rheagroup</groupId>
         <artifactId>cdp4-sdk4j-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -43,7 +43,7 @@
     </scm>
 
     <properties>
-        <cdp4common.version>3.0.0</cdp4common.version>
+        <cdp4common.version>3.1.0</cdp4common.version>
     </properties>
 
     <dependencies>

--- a/cdp4dal/src/main/java/cdp4dal/dal/DalQueryAttributes.java
+++ b/cdp4dal/src/main/java/cdp4dal/dal/DalQueryAttributes.java
@@ -41,33 +41,33 @@ import lombok.experimental.FieldNameConstants;
  */
 @Getter
 @Setter
-@FieldNameConstants(innerTypeName = "FieldNames", level = AccessLevel.PACKAGE)
+@FieldNameConstants(innerTypeName = "FieldNames")
 public class DalQueryAttributes implements QueryAttributes {
 
   /**
    * Gets or sets the {@link ExtentQueryAttribute} of the query.
    */
-  private ExtentQueryAttribute extent;
+  protected ExtentQueryAttribute extent;
 
   /**
    * Gets or sets whether to query the include reference data.
    */
-  private Boolean includeReferenceData;
+  protected Boolean includeReferenceData;
 
   /**
    * Gets or sets whether to include all containers.
    */
-  private Boolean includeAllContainers;
+  protected Boolean includeAllContainers;
 
   /**
    * Gets or sets whether to include the file data.
    */
-  private Boolean includeFileData;
+  protected Boolean includeFileData;
 
   /**
    * Gets or sets the revision number.
    */
-  private Integer revisionNumber;
+  protected Integer revisionNumber;
 
   /**
    * Gets a dictionary of all attributes and attributes name
@@ -82,7 +82,23 @@ public class DalQueryAttributes implements QueryAttributes {
         parameters.put(FieldNames.revisionNumber, String.valueOf(this.getRevisionNumber().intValue()));
      }
 
-     return parameters;
+     if (this.getExtent() != null) {
+       parameters.put(FieldNames.extent, this.getExtent().name());
+     }
+
+     if (this.getIncludeReferenceData() != null) {
+       parameters.put(FieldNames.includeReferenceData, String.valueOf(this.getIncludeReferenceData().booleanValue()));
+     }
+
+     if (this.getIncludeAllContainers() != null) {
+       parameters.put(FieldNames.includeAllContainers, String.valueOf(this.getIncludeAllContainers().booleanValue()));
+     }
+
+     if (this.getIncludeFileData() != null) {
+       parameters.put(FieldNames.includeFileData, String.valueOf(this.getIncludeFileData().booleanValue()));
+     }
+
+    return parameters;
   }
 
   /**

--- a/cdp4dal/src/main/java/cdp4dal/dal/ecss1025annexc/QueryAttributesImpl.java
+++ b/cdp4dal/src/main/java/cdp4dal/dal/ecss1025annexc/QueryAttributesImpl.java
@@ -46,54 +46,6 @@ import lombok.experimental.FieldNameConstants;
 public class QueryAttributesImpl extends DalQueryAttributes {
 
   /**
-   * Gets or sets the {@link ExtentQueryAttribute} of the query.
-   */
-  private ExtentQueryAttribute extent;
-
-  /**
-   * Gets or sets whether to query the include reference data.
-   */
-  private Boolean includeReferenceData;
-
-  /**
-   * Gets or sets whether to include all containers.
-   */
-  private Boolean includeAllContainers;
-
-  /**
-   * Gets or sets whether to include the file data.
-   */
-  private Boolean includeFileData;
-
-  /**
-   * Gets a dictionary of all attributes and attributes name
-   *
-   * @return A {@linkplain Map} of {@linkplain String} attribute name {@linkplain String} value
-   */
-  @Override
-  public Map<String, String> toUriParameters() {
-    Map parameters = super.toUriParameters();
-
-    if (this.getExtent() != null) {
-      parameters.put(FieldNames.extent, this.getExtent().name());
-    }
-
-    if (this.getIncludeReferenceData() != null) {
-      parameters.put(FieldNames.includeReferenceData, String.valueOf(this.getIncludeReferenceData().booleanValue()));
-    }
-
-    if (this.getIncludeAllContainers() != null) {
-      parameters.put(FieldNames.includeAllContainers, String.valueOf(this.getIncludeAllContainers().booleanValue()));
-    }
-
-    if (this.getIncludeFileData() != null) {
-      parameters.put(FieldNames.includeFileData, String.valueOf(this.getIncludeFileData().booleanValue()));
-    }
-
-    return parameters;
-  }
-
-  /**
    * Converts all values of this {@link QueryAttributes} class to a uri attributes String.
    *
    * @return The {@link String} in the form ?param1=value1 separated by an ampersand.

--- a/cdp4emfconnector/pom.xml
+++ b/cdp4emfconnector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
         <groupId>com.rheagroup</groupId>
         <artifactId>cdp4-sdk4j-parent</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <cdp4common.version>3.1.1</cdp4common.version>
+        <cdp4common.version>3.1.0</cdp4common.version>
     </properties>
 
     <dependencies>

--- a/cdp4emfconnector/pom.xml
+++ b/cdp4emfconnector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
         <groupId>com.rheagroup</groupId>
         <artifactId>cdp4-sdk4j-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <cdp4common.version>3.0.0</cdp4common.version>
+        <cdp4common.version>3.1.0</cdp4common.version>
     </properties>
 
     <dependencies>

--- a/cdp4emfconnector/pom.xml
+++ b/cdp4emfconnector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
         <groupId>com.rheagroup</groupId>
         <artifactId>cdp4-sdk4j-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <cdp4common.version>3.1.0</cdp4common.version>
+        <cdp4common.version>3.1.1</cdp4common.version>
     </properties>
 
     <dependencies>

--- a/cdp4jsonfiledal/pom.xml
+++ b/cdp4jsonfiledal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,8 +43,8 @@
   </scm>
 
   <properties>
-    <cdp4dal.version>3.0.0</cdp4dal.version>
-    <cdp4jsonserializer.version>3.0.0</cdp4jsonserializer.version>
+    <cdp4dal.version>3.1.0</cdp4dal.version>
+    <cdp4jsonserializer.version>3.1.0</cdp4jsonserializer.version>
   </properties>
 
   <dependencies>

--- a/cdp4jsonfiledal/pom.xml
+++ b/cdp4jsonfiledal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,8 +43,8 @@
   </scm>
 
   <properties>
-    <cdp4dal.version>3.1.1</cdp4dal.version>
-    <cdp4jsonserializer.version>3.1.1</cdp4jsonserializer.version>
+    <cdp4dal.version>3.1.0</cdp4dal.version>
+    <cdp4jsonserializer.version>3.1.0</cdp4jsonserializer.version>
   </properties>
 
   <dependencies>

--- a/cdp4jsonfiledal/pom.xml
+++ b/cdp4jsonfiledal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,8 +43,8 @@
   </scm>
 
   <properties>
-    <cdp4dal.version>3.1.0</cdp4dal.version>
-    <cdp4jsonserializer.version>3.1.0</cdp4jsonserializer.version>
+    <cdp4dal.version>3.1.1</cdp4dal.version>
+    <cdp4jsonserializer.version>3.1.1</cdp4jsonserializer.version>
   </properties>
 
   <dependencies>

--- a/cdp4jsonserializer/pom.xml
+++ b/cdp4jsonserializer/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>cdp4-sdk4j-parent</artifactId>
     <groupId>com.rheagroup</groupId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
   </scm>
 
   <properties>
-    <cdp4common.version>3.0.0</cdp4common.version>
+    <cdp4common.version>3.1.0</cdp4common.version>
   </properties>
 
   <dependencies>

--- a/cdp4jsonserializer/pom.xml
+++ b/cdp4jsonserializer/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>cdp4-sdk4j-parent</artifactId>
     <groupId>com.rheagroup</groupId>
-    <version>3.1.1</version>
+    <version>3.1.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
   </scm>
 
   <properties>
-    <cdp4common.version>3.1.1</cdp4common.version>
+    <cdp4common.version>3.1.0</cdp4common.version>
   </properties>
 
   <dependencies>

--- a/cdp4jsonserializer/pom.xml
+++ b/cdp4jsonserializer/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>cdp4-sdk4j-parent</artifactId>
     <groupId>com.rheagroup</groupId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
   </scm>
 
   <properties>
-    <cdp4common.version>3.1.0</cdp4common.version>
+    <cdp4common.version>3.1.1</cdp4common.version>
   </properties>
 
   <dependencies>

--- a/cdp4requirementsverification/pom.xml
+++ b/cdp4requirementsverification/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cdp4-sdk4j</artifactId>
         <groupId>com.rheagroup</groupId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -41,7 +41,7 @@
     </scm>
 
     <properties>
-        <cdp4dal.version>3.0.0</cdp4dal.version>
+        <cdp4dal.version>3.1.0</cdp4dal.version>
     </properties>
 
     <dependencies>

--- a/cdp4requirementsverification/pom.xml
+++ b/cdp4requirementsverification/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cdp4-sdk4j</artifactId>
         <groupId>com.rheagroup</groupId>
-        <version>3.1.1</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -41,7 +41,7 @@
     </scm>
 
     <properties>
-        <cdp4dal.version>3.1.1</cdp4dal.version>
+        <cdp4dal.version>3.1.0</cdp4dal.version>
     </properties>
 
     <dependencies>

--- a/cdp4requirementsverification/pom.xml
+++ b/cdp4requirementsverification/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cdp4-sdk4j</artifactId>
         <groupId>com.rheagroup</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -41,7 +41,7 @@
     </scm>
 
     <properties>
-        <cdp4dal.version>3.1.0</cdp4dal.version>
+        <cdp4dal.version>3.1.1</cdp4dal.version>
     </properties>
 
     <dependencies>

--- a/cdp4servicesdal/pom.xml
+++ b/cdp4servicesdal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,8 +43,8 @@
   </scm>
 
   <properties>
-    <cdp4dal.version>3.0.0</cdp4dal.version>
-    <cdp4jsonserializer.version>3.0.0</cdp4jsonserializer.version>
+    <cdp4dal.version>3.1.0</cdp4dal.version>
+    <cdp4jsonserializer.version>3.1.0</cdp4jsonserializer.version>
   </properties>
 
   <dependencies>

--- a/cdp4servicesdal/pom.xml
+++ b/cdp4servicesdal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,8 +43,8 @@
   </scm>
 
   <properties>
-    <cdp4dal.version>3.1.1</cdp4dal.version>
-    <cdp4jsonserializer.version>3.1.1</cdp4jsonserializer.version>
+    <cdp4dal.version>3.1.0</cdp4dal.version>
+    <cdp4jsonserializer.version>3.1.0</cdp4jsonserializer.version>
   </properties>
 
   <dependencies>

--- a/cdp4servicesdal/pom.xml
+++ b/cdp4servicesdal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,8 +43,8 @@
   </scm>
 
   <properties>
-    <cdp4dal.version>3.1.0</cdp4dal.version>
-    <cdp4jsonserializer.version>3.1.0</cdp4jsonserializer.version>
+    <cdp4dal.version>3.1.1</cdp4dal.version>
+    <cdp4jsonserializer.version>3.1.1</cdp4jsonserializer.version>
   </properties>
 
   <dependencies>

--- a/cdp4servicesdal/src/main/java/cdp4servicesdal/CdpServicesDal.java
+++ b/cdp4servicesdal/src/main/java/cdp4servicesdal/CdpServicesDal.java
@@ -567,8 +567,24 @@ public class CdpServicesDal extends DalBase {
    */
   public URI getUri(URI uri, QueryAttributes queryAttributes, String... segments) throws URISyntaxException {
 
-    URIBuilder uriBuilder = new URIBuilder(uri)
-            .setPathSegments(Stream.of(segments).filter(x -> !StringUtils.isBlank(x)).collect(Collectors.toList()));
+    List<String> decodedSegments = new ArrayList<>();
+
+    for (String segment : Stream.of(segments).filter(x -> !StringUtils.isBlank(x)).collect(Collectors.toList()))
+    {
+      if(segment.contains("/"))
+      {
+        for (String part : Stream.of(segment.split("/")).filter(x -> !StringUtils.isBlank(x)).collect(Collectors.toList()))
+        {
+          decodedSegments.add(part);
+        }
+      }
+      else
+      {
+        decodedSegments.add(segment);
+      }
+    }
+
+    URIBuilder uriBuilder = new URIBuilder(uri).setPathSegments(decodedSegments);
 
     for (Map.Entry<String, String> parameter : queryAttributes.toUriParameters().entrySet())
     {

--- a/cdp4servicesdal/src/main/java/cdp4servicesdal/CdpServicesDal.java
+++ b/cdp4servicesdal/src/main/java/cdp4servicesdal/CdpServicesDal.java
@@ -66,6 +66,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -546,14 +547,15 @@ public class CdpServicesDal extends DalBase {
    */
   public URI getUri(URI baseUri, QueryAttributes queryAttributes, Thing thing, String... segments) throws URISyntaxException {
 
-    URI uri = this.getUri(baseUri, queryAttributes, segments);
+    List<String> segmentsWithThing = new ArrayList<>();
+    segmentsWithThing.addAll(Arrays.asList(segments));
 
     if(!StringUtils.isBlank(thing.getRoute()))
     {
-      return uri.resolve(new URI(thing.getRoute()));
+      segmentsWithThing.addAll(Arrays.asList(thing.getRoute().split("/")));
     }
 
-    return uri;
+    return this.getUri(baseUri, queryAttributes, segmentsWithThing.toArray(new String[0]));
   }
 
   /**

--- a/cdp4servicesdal/src/test/java/cdp4servicesdal/CdpServicesDalTest.java
+++ b/cdp4servicesdal/src/test/java/cdp4servicesdal/CdpServicesDalTest.java
@@ -250,12 +250,37 @@ class CdpServicesDalTest {
   @Test
   void verifyUriIsBuiltCorrectly() throws URISyntaxException
   {
+    URI baseUri = URI.create("https://cdp4services-test.cdp4.org");
     QueryAttributesImpl queryAttributes = new QueryAttributesImpl();
     queryAttributes.setExtent(ExtentQueryAttribute.deep);
     queryAttributes.setIncludeReferenceData(false);
 
-    URI uri = this.dal.getUri(URI.create("https://cdp4services-test.cdp4.org"), queryAttributes, "SiteDirectory");
-    assertFalse(uri.toString().contains("%3F"));
+    URI uri = this.dal.getUri(baseUri, queryAttributes, "SiteDirectory");
+    assertFalse(uri.toString().contains("%2F"));
+
+    cdp4common.dto.SiteDirectory thing = new cdp4common.dto.SiteDirectory();
+    thing.setIid(UUID.randomUUID());
+
+    uri = this.dal.getUri(baseUri, queryAttributes, thing, "SiteDirectory");
+    assertFalse(uri.toString().contains("%2F"));
+  }
+
+  @Test
+  void verifyUriIsBuiltCorrectlyWhenPassingUnescapedString() throws URISyntaxException
+  {
+    URI baseUri = URI.create("https://cdp4services-test.cdp4.org");
+    QueryAttributesImpl queryAttributes = new QueryAttributesImpl();
+    queryAttributes.setExtent(ExtentQueryAttribute.deep);
+    queryAttributes.setIncludeReferenceData(false);
+
+    URI uri = this.dal.getUri(baseUri, queryAttributes, "SiteDirectory/545257ce-35c2-46bc-836a-08875468c22b");
+    assertFalse(uri.toString().contains("%2F"));
+
+    cdp4common.dto.SiteDirectory thing = new cdp4common.dto.SiteDirectory();
+    thing.setIid(UUID.randomUUID());
+
+    uri = this.dal.getUri(baseUri, queryAttributes, "SiteDirectory/545257ce-35c2-46bc-836a-08875468c22b");
+    assertFalse(uri.toString().contains("%2F"));
   }
 
   @Test

--- a/cdp4wspdal/pom.xml
+++ b/cdp4wspdal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,8 +43,8 @@
   </scm>
 
   <properties>
-    <cdp4dal.version>3.0.0</cdp4dal.version>
-    <cdp4jsonserializer.version>3.0.0</cdp4jsonserializer.version>
+    <cdp4dal.version>3.1.0</cdp4dal.version>
+    <cdp4jsonserializer.version>3.1.0</cdp4jsonserializer.version>
   </properties>
 
   <dependencies>

--- a/cdp4wspdal/pom.xml
+++ b/cdp4wspdal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,8 +43,8 @@
   </scm>
 
   <properties>
-    <cdp4dal.version>3.1.1</cdp4dal.version>
-    <cdp4jsonserializer.version>3.1.1</cdp4jsonserializer.version>
+    <cdp4dal.version>3.1.0</cdp4dal.version>
+    <cdp4jsonserializer.version>3.1.0</cdp4jsonserializer.version>
   </properties>
 
   <dependencies>

--- a/cdp4wspdal/pom.xml
+++ b/cdp4wspdal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -43,8 +43,8 @@
   </scm>
 
   <properties>
-    <cdp4dal.version>3.1.0</cdp4dal.version>
-    <cdp4jsonserializer.version>3.1.0</cdp4jsonserializer.version>
+    <cdp4dal.version>3.1.1</cdp4dal.version>
+    <cdp4jsonserializer.version>3.1.1</cdp4jsonserializer.version>
   </properties>
 
   <dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.rheagroup</groupId>
   <artifactId>cdp4-sdk4j-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.1.0</version>
+  <version>3.1.1</version>
   <name>CDP4 SDK Java Implementation Project Parent</name>
   <description>A parent pom that is used by all CDP4 modules</description>
   <url>https://github.com/RHEAGROUP/CDP4-SDKJ-Community-Edition</url>
@@ -67,7 +67,7 @@
     <intellij.version>12.0</intellij.version>
     <jaxb.version>2.3.0</jaxb.version>
     <mvn.compiler.version>3.8.0</mvn.compiler.version>
-    <mvn.source.version>3.1.0</mvn.source.version>
+    <mvn.source.version>3.1.1</mvn.source.version>
     <mvn.javadoc.version>3.1.1</mvn.javadoc.version>
     <mvn.gpg.version>1.6</mvn.gpg.version>
     <mvn.surefire.version>2.22.1</mvn.surefire.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.rheagroup</groupId>
   <artifactId>cdp4-sdk4j-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.1.1</version>
+  <version>3.1.0</version>
   <name>CDP4 SDK Java Implementation Project Parent</name>
   <description>A parent pom that is used by all CDP4 modules</description>
   <url>https://github.com/RHEAGROUP/CDP4-SDKJ-Community-Edition</url>
@@ -67,7 +67,7 @@
     <intellij.version>12.0</intellij.version>
     <jaxb.version>2.3.0</jaxb.version>
     <mvn.compiler.version>3.8.0</mvn.compiler.version>
-    <mvn.source.version>3.1.1</mvn.source.version>
+    <mvn.source.version>3.1.0</mvn.source.version>
     <mvn.javadoc.version>3.1.1</mvn.javadoc.version>
     <mvn.gpg.version>1.6</mvn.gpg.version>
     <mvn.surefire.version>2.22.1</mvn.surefire.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.rheagroup</groupId>
   <artifactId>cdp4-sdk4j-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.0.0</version>
+  <version>3.1.0</version>
   <name>CDP4 SDK Java Implementation Project Parent</name>
   <description>A parent pom that is used by all CDP4 modules</description>
   <url>https://github.com/RHEAGROUP/CDP4-SDKJ-Community-Edition</url>
@@ -410,15 +410,13 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus.staging.plugin.version}</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.1.2</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <!-- Set this to true and the release will automatically proceed and sync to Central Repository will follow  -->
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+              <publishingServerId>ossrh</publishingServerId>
+              <tokenEnabled>true</tokenEnabled>
             </configuration>
           </plugin>
           <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -410,13 +410,14 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.1.2</version>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>${nexus.staging.plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
-              <publishingServerId>ossrh</publishingServerId>
-              <tokenEnabled>true</tokenEnabled>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
             </configuration>
           </plugin>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <relativePath>./parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <relativePath>./parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.rheagroup</groupId>
     <artifactId>cdp4-sdk4j-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.0</version>
     <relativePath>./parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-SDKJ-Community-Edition/pulls) open
- [ ] I have verified that I am following the COMET-SDKJ [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-SDKJ-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
- [x] Moved QueryAttributesImpl fields to DalQueryAttributes (They were overridden)
- [x] Roll back to split the thing route for URI segment building
- [x] Updated Sonatype configuration to match latest documentation on publishing on Sonatype and central
- [x] Bumped version number
<!-- Thanks for contributing to COMET-SDKJ! -->